### PR TITLE
Add null guard to LogName attribute lookup

### DIFF
--- a/Core/Attributes/LogNameAttributeExtension.cs
+++ b/Core/Attributes/LogNameAttributeExtension.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace VisionNet.Logging
 {
@@ -11,6 +12,11 @@ namespace VisionNet.Logging
         /// <returns> The value of the logname property in the lognameattribute class</returns>
         public static string GetLogName(this object obj)
         {
+            if (obj is null)
+            {
+                // GUARD: Prevent null dereference when retrieving the object's log name attribute.
+                throw new ArgumentNullException(nameof(obj));
+            }
 
             var attribute = obj.GetType()
                 .GetCustomAttributes(true)


### PR DESCRIPTION
## Summary
- add a null check to GetLogName to prevent dereferencing null objects
- document the guard with a GUARD comment per bugfix guidelines
- import System to access ArgumentNullException

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caabca42e48333b41a9f4233dfed3b