### PR TITLE
Document GenericSafeObject semantics

### DIFF
--- a/Core/SafeObjects/GenericSafeObject.cs
+++ b/Core/SafeObjects/GenericSafeObject.cs
@@ -14,11 +14,20 @@ using VisionNet.Core.Exceptions;
 
 namespace VisionNet.Core.SafeObjects
 {
+    /// <summary>
+    /// Provides a thread-safe container for a single value that is validated against a declared <see cref="DataType" />
+    /// type, ensuring only compatible objects are stored and retrieved safely.
+    /// </summary>
     public class GenericSafeObject : ISafeObject<Type>
     {
         protected object _lockObject = new object();
         protected object _value;
 
+        /// <summary>
+        /// Gets the runtime <see cref="Type" /> that any stored value must be assignable to in order to be accepted by the
+        /// safe object.
+        /// </summary>
+        /// <value>The expected <see cref="Type" /> for validated values; defaults to <see cref="object" />.</value>
         public Type DataType { get; protected set; }
 
         


### PR DESCRIPTION
## Summary
- document GenericSafeObject to describe its thread-safe safe-object semantics
- clarify DataType property contract and default behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cab4090c6c83338fff380d2d721ae0