### PR TITLE
Document RegexHelper.IsValidRegex

### DIFF
--- a/Core/RegularExpressions/RegexHelper.cs
+++ b/Core/RegularExpressions/RegexHelper.cs
@@ -7,6 +7,12 @@ namespace VisionNet.Core.RegularExpressions
 {
     public static class RegexHelper
     {
+        /// <summary>
+        /// Determines whether the provided pattern can be compiled into a regular expression by instantiating a <see cref="Regex"/>.
+        /// </summary>
+        /// <param name="pattern">The regular expression pattern to validate; may be <c>null</c> or empty.</param>
+        /// <returns><c>true</c> if the pattern can be compiled into a <see cref="Regex"/> instance; otherwise, <c>false</c> when the pattern is <c>null</c>, malformed, or contains unsupported constructs.</returns>
+        /// <remarks>Any <see cref="ArgumentException"/> thrown during compilation (including <see cref="ArgumentNullException"/>) is caught, and the method returns <c>false</c> instead of propagating the exception.</remarks>
         public static bool IsValidRegex(string pattern)
         {
             try


### PR DESCRIPTION
## Summary
- add XML documentation to `RegexHelper.IsValidRegex` detailing validation behavior and return semantics

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68cab406cdf083338650e8cd9e55cd3e