### PR TITLE
Add XML documentation to ModelBase

### DIFF
--- a/Core/Patterns/Model/ModelBase.cs
+++ b/Core/Patterns/Model/ModelBase.cs
@@ -12,6 +12,11 @@
 
 namespace VisionNet.Core.Patterns
 {
+    /// <summary>
+    /// Provides a base implementation for model objects that wrap a domain object and
+    /// expose change notification capabilities through <see cref="ObservableObject"/>.
+    /// </summary>
+    /// <typeparam name="DM">Type of the domain object represented by the model.</typeparam>
     public abstract class ModelBase<DM> : ObservableObject
     {
         #region Constructor
@@ -25,6 +30,9 @@ namespace VisionNet.Core.Patterns
 
         #region Properties
 
+        /// <summary>
+        /// Gets or sets the domain object instance associated with the model.
+        /// </summary>
         public DM DomainObject { get; set; }
 
         #endregion


### PR DESCRIPTION
## Summary
- add XML documentation for the generic ModelBase class
- document the DomainObject property to describe its purpose

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cab3fe16688333891d19cf383ca58a