### PR TITLE
Add XML documentation to VisionNetException

### DIFF
--- a/Core/Exceptions/VisionNetException.cs
+++ b/Core/Exceptions/VisionNetException.cs
@@ -16,46 +16,58 @@ using System.Security.Permissions;
 namespace VisionNet.Core.Exceptions
 {
     /// <summary>
-    /// Image conversion exception.
+    /// Represents errors that occur while performing VisionNet operations.
     /// </summary>
     [Serializable]
     public class VisionNetException : Exception
     {
+        /// <summary>
+        /// Gets or sets the resource reference identifier associated with the exception instance.
+        /// </summary>
+        /// <value>
+        /// A <see cref="string"/> token that identifies the resource tied to the failure; this value can be <see langword="null"/>.
+        /// </value>
         public string ResourceReferenceProperty { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="VisionNetException"/> class.
+        /// Initializes a new instance of the <see cref="VisionNetException"/> class with a default error description.
         /// </summary>
         public VisionNetException() { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="VisionNetException"/> class.
+        /// Initializes a new instance of the <see cref="VisionNetException"/> class with a specific error message.
         /// </summary>
-        /// <param name="message">Message providing some additional information.</param>
+        /// <param name="message">A human-readable description of the error condition.</param>
         public VisionNetException(string message) : base(message) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="VisionNetException"/> class.
+        /// Initializes a new instance of the <see cref="VisionNetException"/> class with a specific error message and inner exception.
         /// </summary>
-        /// <param name="message">Message providing some additional information.</param>
-        /// <param name="inner">The exception that is the cause of the current exception.</param>
+        /// <param name="message">A human-readable description of the error condition.</param>
+        /// <param name="inner">The exception that caused the current exception to be thrown.</param>
         public VisionNetException(string message, Exception inner) : base(message, inner) { }
 
-        ///<summary> 
-        /// Initializes a new instance of the<see cref="VisionNetException"/> class. 
-        ///</summary> 
-        ///<param name = "info" > The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param> 
-        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisionNetException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">
+        /// The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.
+        /// </param>
+        /// <param name="context">
+        /// The <see cref="StreamingContext"/> that contains contextual information about the source or destination.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="info"/> is <see langword="null"/>.</exception>
         protected VisionNetException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             ResourceReferenceProperty = info.GetString("ResourceReferenceProperty");
         }
 
-        ///<summary> 
-        /// When overridden in a derived class, sets the<see cref="SerializationInfo"/> with information about the exception. 
-        ///</summary> 
-        ///<param name = "info"> The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param> 
-        ///<param name = "context"> The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param> 
+        /// <summary>
+        /// Sets the <see cref="SerializationInfo"/> with information about the exception.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="info"/> is <see langword="null"/>.</exception>
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {


### PR DESCRIPTION
## Summary
- expand the VisionNetException class documentation to describe its role and serialization behavior
- document ResourceReferenceProperty and all public constructors for improved API clarity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cab3f81ee4833392a7556375e37459