### PR TITLE
Add XML documentation to ChangeTracker

### DIFF
--- a/Core/Comparisons/ChangeTracker.cs
+++ b/Core/Comparisons/ChangeTracker.cs
@@ -7,14 +7,28 @@ using System.Reflection;
 
 namespace VisionNet.Core.Comparisons
 {
+    /// <summary>
+    /// Provides change tracking utilities for complex object graphs by recording paths to members whose values differ.
+    /// </summary>
     public class ChangeTracker
     {
         private readonly ConcurrentBag<string> _changedProperties = new ConcurrentBag<string>();
 
+        /// <summary>
+        /// Gets the collection of property paths that have been recorded as changed.
+        /// </summary>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> containing the full paths of detected changes. The collection is empty when no differences have been found.</returns>
         public IReadOnlyCollection<string> ChangedProperties => _changedProperties;
 
+        /// <summary>
+        /// Gets a value indicating whether any changes have been recorded.
+        /// </summary>
+        /// <returns><see langword="true"/> when at least one change has been tracked; otherwise, <see langword="false"/>.</returns>
         public bool HasChanges => !_changedProperties.IsEmpty;
 
+        /// <summary>
+        /// Clears all recorded change information.
+        /// </summary>
         public void Clear()
         {
             while (!_changedProperties.IsEmpty)
@@ -23,6 +37,16 @@ namespace VisionNet.Core.Comparisons
             }
         }
 
+        /// <summary>
+        /// Compares two object graphs and records the paths of differing members.
+        /// </summary>
+        /// <param name="original">The baseline instance whose values are treated as the source of truth. May be <see langword="null"/>.</param>
+        /// <param name="modified">The instance to compare against <paramref name="original"/>. May be <see langword="null"/>.</param>
+        /// <param name="prefix">An optional prefix describing the path to the objects being compared, typically a parent property path.</param>
+        /// <remarks>
+        /// The comparison recurses through lists, dictionaries, and readable public properties, recording differences as dot-separated paths or indexed segments.
+        /// </remarks>
+        /// <exception cref="TargetInvocationException">Thrown when accessing a property via reflection invokes a getter that throws an exception.</exception>
         public void TrackDiff(object original, object modified, string prefix = "")
         {
             if (original == null && modified == null) return;
@@ -107,6 +131,10 @@ namespace VisionNet.Core.Comparisons
             }
         }
 
+        /// <summary>
+        /// Explicitly marks a property path as changed.
+        /// </summary>
+        /// <param name="propertyName">The property path to record. Leading or trailing whitespace is ignored.</param>
         public void TrackChange(string propertyName)
         {
             if (!string.IsNullOrWhiteSpace(propertyName))


### PR DESCRIPTION
## Summary
- add class-level XML documentation describing the ChangeTracker responsibilities
- document public members with summaries, return descriptions, and notable exceptions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cab3f35f688333871bb779f44b239d