### PR TITLE
Add XML documentation to bits helper conversions

### DIFF
--- a/Core/Bitwise/Bits.Helpers.cs
+++ b/Core/Bitwise/Bits.Helpers.cs
@@ -7,19 +7,49 @@
 // Last Modified On : 18-11-2023
 // Description      : v1.7.1
 //
-// Copyright        : (C)  2023 by Sothis/Nunsys. All rights reserved.       
+// Copyright        : (C)  2023 by Sothis/Nunsys. All rights reserved.
 //----------------------------------------------------------------------------
 using System;
 
 namespace VisionNet.Core.Bitwise
 {
+    /// <summary>
+    /// Provides helper routines used by <see cref="Bits"/> partial implementations when performing unchecked bitwise conversions.
+    /// </summary>
     public static partial class Bits
     {
+        /// <summary>
+        /// Throws a standardized <see cref="IndexOutOfRangeException"/> when a bit index exceeds the supported range.
+        /// </summary>
+        /// <exception cref="IndexOutOfRangeException">Always thrown to signal that a requested bit index is outside the valid range.</exception>
         private static void ThrowIndexOutOfRange() => throw new IndexOutOfRangeException();
 
+        /// <summary>
+        /// Reinterprets a signed 64-bit integer as its unsigned counterpart without performing overflow checks.
+        /// </summary>
+        /// <param name="value">Signed 64-bit integer value to convert to an unsigned representation.</param>
+        /// <returns>The bitwise equivalent unsigned 64-bit integer.</returns>
         internal static ulong ToUnsigned(long value) => unchecked((ulong)value);
+
+        /// <summary>
+        /// Reinterprets a signed 32-bit integer as its unsigned counterpart without performing overflow checks.
+        /// </summary>
+        /// <param name="value">Signed 32-bit integer value to convert to an unsigned representation.</param>
+        /// <returns>The bitwise equivalent unsigned 32-bit integer.</returns>
         internal static uint ToUnsigned(int value) => unchecked((uint)value);
+
+        /// <summary>
+        /// Reinterprets a signed 16-bit integer as its unsigned counterpart without performing overflow checks.
+        /// </summary>
+        /// <param name="value">Signed 16-bit integer value to convert to an unsigned representation.</param>
+        /// <returns>The bitwise equivalent unsigned 16-bit integer.</returns>
         internal static ushort ToUnsigned(short value) => unchecked((ushort)value);
+
+        /// <summary>
+        /// Reinterprets a signed 8-bit integer as its unsigned counterpart without performing overflow checks.
+        /// </summary>
+        /// <param name="value">Signed 8-bit integer value to convert to an unsigned representation.</param>
+        /// <returns>The bitwise equivalent unsigned 8-bit integer.</returns>
         internal static byte ToUnsigned(sbyte value) => unchecked((byte)value);
     }
 }


### PR DESCRIPTION
## Summary
- document the Bits helper partial class to describe its role in bitwise utilities
- add XML documentation for bit reinterpretation helpers covering parameters and return values
- clarify the dedicated exception helper's behavior and error conditions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cab3eda22883339c55c15f273db970