### PR TITLE
Add XML documentation to LogNameAttribute

### DIFF
--- a/Core/Attributes/LogNameAttribute.cs
+++ b/Core/Attributes/LogNameAttribute.cs
@@ -2,15 +2,21 @@
 
 namespace VisionNet.Logging
 {
+    /// <summary>
+    /// Specifies the log name that should be associated with the decorated class when emitting log entries.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
     public class LogNameAttribute: Attribute
     {
+        /// <summary>
+        /// Represents the log name assigned through the attribute to categorize log output.
+        /// </summary>
         public string LogName;
 
-        
-        /// <summary> The LogNameAttribute function is used to set the name of a log file.</summary>
-        /// <param name="string logName"> The name of the log file.</param>
-        /// <returns> The name of the log.</returns>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogNameAttribute"/> class using the provided log name identifier.
+        /// </summary>
+        /// <param name="logName">Log identifier to associate with the decorated class when logging.</param>
         public LogNameAttribute(string logName)
         {
             LogName = logName;


### PR DESCRIPTION
## Summary
- add XML documentation to the LogNameAttribute class describing its purpose, log name member, and constructor parameter

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cab3ed677c83338b267c734c0ad136