### PR TITLE
Add XML docs to TransactionalAction

### DIFF
--- a/Core/Threading/TransactionalAction.cs
+++ b/Core/Threading/TransactionalAction.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 
 namespace VisionNet.Core.Threading
 {
+    /// <summary>
+    /// Provides a synchronization primitive that serializes access to actions identified by a shared identifier and releases
+    /// the identifier-specific lock when disposed.
+    /// </summary>
     public class TransactionalAction: IDisposable
     {
         private readonly object _lockObject;
@@ -10,6 +14,11 @@ namespace VisionNet.Core.Threading
         private static readonly object _lockCreationObject = new object();
         private readonly string _id;
         private bool disposed = false;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TransactionalAction"/> class for the specified identifier.
+        /// </summary>
+        /// <param name="id">An identifier used to group actions that must not execute concurrently.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="id"/> is <see langword="null"/>.</exception>
         public TransactionalAction(string id)
         {
             _id = id;
@@ -29,6 +38,12 @@ namespace VisionNet.Core.Threading
             }
         }
 
+        /// <summary>
+        /// Executes the provided action while holding the lock associated with this instance's identifier, ensuring exclusive execution among peers that share the same identifier.
+        /// </summary>
+        /// <param name="action">A delegate to invoke while the identifier-specific lock is held.</param>
+        /// <exception cref="NullReferenceException">Thrown when <paramref name="action"/> is <see langword="null"/>.</exception>
+        /// <exception cref="Exception">Any exception thrown by <paramref name="action"/> propagates to the caller.</exception>
         public void Execute(Action action)
         {
             lock (_lockObject)
@@ -37,12 +52,20 @@ namespace VisionNet.Core.Threading
             }
         }
 
+        /// <summary>
+        /// Releases resources associated with this instance and removes the identifier-specific lock, allowing future instances with the same identifier to create a new lock object.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Releases managed resources associated with the instance, removing the identifier-specific lock when invoked from
+        /// <see cref="Dispose()"/>.
+        /// </summary>
+        /// <param name="disposing">Indicates whether the method is invoked from <see cref="Dispose()"/>.</param>
         protected virtual void Dispose(bool disposing)
         {
             if (!disposed)


### PR DESCRIPTION
## Summary
- add XML documentation for TransactionalAction to describe concurrency usage and disposal behavior

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cab3e1ffdc8333be2db5ae7f602654