### PR TITLE
Add XML documentation for secure string helpers

### DIFF
--- a/Core/Security/SecureStringHelper.cs
+++ b/Core/Security/SecureStringHelper.cs
@@ -16,7 +16,22 @@ namespace VisionNet.Core.Security
 {
     public static class SecureStringHelper
     {
+        /// <summary>
+        /// Converts the provided <see cref="SecureString"/> into a managed <see cref="string"/> instance by leveraging <see cref="NetworkCredential"/>.
+        /// </summary>
+        /// <param name="source">Secure text to convert. May be empty, but must not be disposed when invoked.</param>
+        /// <returns>A managed string containing the decrypted value of <paramref name="source"/>. Returns <see cref="string.Empty"/> when the secure string is empty.</returns>
+        /// <exception cref="ObjectDisposedException">Thrown when <paramref name="source"/> has already been disposed.</exception>
+        /// <remarks>The resulting string resides in managed memory and should be handled carefully to avoid lingering sensitive data.</remarks>
         public static string FromSecureString(this SecureString source) => new NetworkCredential("", source).Password;
+
+        /// <summary>
+        /// Converts the specified <see cref="string"/> into a new <see cref="SecureString"/> by assigning it through <see cref="NetworkCredential"/>.
+        /// </summary>
+        /// <param name="source">Plain text value to protect. May be <see langword="null"/>, in which case an empty secure string is returned.</param>
+        /// <returns>A new <see cref="SecureString"/> instance whose contents mirror <paramref name="source"/>.</returns>
+        /// <exception cref="OutOfMemoryException">Thrown when the runtime cannot allocate the secure string.</exception>
+        /// <remarks>The caller is responsible for disposing the returned secure string as soon as it is no longer required.</remarks>
         public static SecureString ToSecureString(this string source) => new NetworkCredential("", source).SecurePassword;
 
         


### PR DESCRIPTION
## Summary
- add XML documentation for converting secure strings to managed strings
- describe secure handling guidance for string to secure string conversion

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cba79ffd6883338bdc60774eb27e16