### PR TITLE
Add XML documentation for password encryption helper

### DIFF
--- a/Core/Security/PasswordEncriptDecriptHelper.cs
+++ b/Core/Security/PasswordEncriptDecriptHelper.cs
@@ -15,7 +15,14 @@ namespace VisionNet.Core.Security
 {
     public static class PasswordEncriptDecriptHelper
     {
-        // Encripta una cadena
+        /// <summary>
+        /// Encrypts the contents of the provided <see cref="SecureString"/> using the specified encryption algorithm.
+        /// </summary>
+        /// <param name="source">Secure string containing the plaintext to encrypt. Must not be <see langword="null"/>; may be empty to produce an empty result.</param>
+        /// <param name="encriptMethod">Encryption strategy to apply. Defaults to <see cref="EncriptMethod.Base64"/>; use <see cref="EncriptMethod.ECB"/> for TripleDES ECB mode.</param>
+        /// <returns>A non-null string containing the encrypted representation of <paramref name="source"/>. The value is empty when the input is empty.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="System.Security.Cryptography.CryptographicException">Thrown when the encryption provider cannot be initialized or fails while processing <paramref name="source"/> when using <see cref="EncriptMethod.ECB"/>.</exception>
         public static string Encript(this SecureString source, EncriptMethod encriptMethod = EncriptMethod.Base64)
             => new PasswordEncriptDecript().Encript(source, encriptMethod);
 


### PR DESCRIPTION
## Summary
- add XML documentation for the `PasswordEncriptDecriptHelper.Encript` extension method, including parameter, return, and exception details

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cab8d79a7083338579d6bbf9d434b2